### PR TITLE
ByteStreamVar doesn't autodereference to ByteStream

### DIFF
--- a/serialization.nim
+++ b/serialization.nim
@@ -89,7 +89,7 @@ template loadFile*(Format: distinct type,
                    params: varargs[untyped]): auto =
   mixin init, ReaderType
   var stream = openFile(filename)
-  defer: stream.close() # TODO: destructors
+  defer: stream[].close() # TODO: destructors
 
   # TODO:
   # Remove this when statement once the following bug is fixed:


### PR DESCRIPTION
fix https://github.com/status-im/nim-beacon-chain/pull/436#issuecomment-530391076

Alternatives are:
  - expose a close for ByteStreamVar in fast-streams
  - have a finalizer in fast-streams