### PR TITLE
Use the latest FastStreams API and take advantage of fixes in Nim 1.2

### DIFF
--- a/serialization.nim
+++ b/serialization.nim
@@ -129,7 +129,7 @@ template borrowSerialization*(Alias: distinct type,
     mixin readValue
     value = Alias reader.readValue(OriginalType)
 
-template appendValue*(stream: OutputStreamVar, Format: type, value: auto) =
+template appendValue*(stream: OutputStream, Format: type, value: auto) =
   mixin WriterType, init, writeValue
   var writer = init(WriterType(Format), stream)
   writeValue writer, value

--- a/serialization/testing/generic_suite.nim
+++ b/serialization/testing/generic_suite.nim
@@ -56,7 +56,7 @@ type
     B
 
   CaseObject* = object
-   case kind*: ObjectKind:
+   case kind*: ObjectKind
    of A:
      a*: int
      other*: CaseObjectRef

--- a/serialization/testing/generic_suite.nim
+++ b/serialization/testing/generic_suite.nim
@@ -316,7 +316,7 @@ proc executeReaderWriterTests*(Format: type) =
       check fieldReader != nil and idx == 1
 
       var bytes = Format.encode("test")
-      var stream = memoryStream(bytes)
+      var stream = memoryInput(bytes)
       var reader = Reader.init(stream)
 
       var bar: Bar


### PR DESCRIPTION
Since merging this is needed for status-im/nim-beacon-chain#890 and to avoid CI breakages in dependent packages, I'll merge it quickly. Feel free to leave review comments that will be addressed in follow up PRs.