### PR TITLE
Stricter error handling

### DIFF
--- a/serialization/errors.nim
+++ b/serialization/errors.nim
@@ -3,6 +3,7 @@ type
   UnexpectedEofError* = object of SerializationError
   CustomSerializationError* = object of SerializationError
 
-method formatMsg*(err: ref SerializationError, filename: string): string {.gcsafe, base.} =
+method formatMsg*(err: ref SerializationError, filename: string): string
+                 {.gcsafe, base, raises: [Defect].} =
   "Serialisation error while processing " & filename
 


### PR DESCRIPTION
This eliminates some sources of `raises: [Exception]` manifesting in the the Json serializer.