### PR TITLE
avoid implicit synthesis of `CaseTransition`

### DIFF
--- a/serialization/object_serialization.nim
+++ b/serialization/object_serialization.nim
@@ -228,6 +228,9 @@ proc makeFieldReadersTable(RecordType, ReaderType: distinct type,
         when RecordType is tuple:
           reader.readValue obj[i]
         else:
+          static: doAssert not isCaseObject(typeof(obj)),
+            "Case object `" & $typeof(obj) &
+            "` must have custom `readValue` for `" & $typeof(reader) & "`"
           type F = FieldTag[RecordType, realFieldName]
           field(obj, realFieldName) = readFieldIMPL(F, reader)
       except SerializationError as err:
@@ -419,4 +422,3 @@ macro useCustomSerialization*(Format: typed, field: untyped, body: untyped): unt
 
   when defined(debugUseCustomSerialization):
     echo result.repr
-


### PR DESCRIPTION
Transitioning the case of a case object without full reinitialization leads to undefined behaviour. Don't do such transitions implicitly, and require explicit `readValue` override for such types in those cases.