### PR TITLE
workaround for `NimYAML` issue

### DIFF
--- a/serialization/object_serialization.nim
+++ b/serialization/object_serialization.nim
@@ -186,21 +186,21 @@ template GetFieldType(FT: type FieldTag): type =
 template readFieldIMPL[Reader](field: type FieldTag,
                                reader: var Reader): auto =
   mixin readValue
-  type FieldType = GetFieldType(field)
+  # Nim 1.6.12: `type FieldType = GetFieldType(field)` here breaks `NimYAML`.
   {.gcsafe.}: # needed by Nim-1.6
-    # TODO: The `FieldType` coercion below is required to deal
+    # TODO: The `GetFieldType(field)` coercion below is required to deal
     # with a nim bug caused by the distinct `ssz.List` type.
     # It seems to break the generics cache mechanism, which
     # leads to an incorrect return type being reported from
     # the `readFieldIMPL` function.
 
-    # additional notes: putting the FieldType coercion in
+    # additional notes: putting the GetFieldType(field) coercion in
     # `makeFieldReadersTable` will cause problems when orc enabled
     # hence, move it here
-    when distinctBase(FieldType) isnot FieldType:
-      FieldType reader.readValue(FieldType)
+    when distinctBase(GetFieldType(field)) isnot GetFieldType(field):
+      GetFieldType(field) reader.readValue(GetFieldType(field))
     else:
-      reader.readValue(FieldType)
+      reader.readValue(GetFieldType(field))
 
 template writeFieldIMPL*[Writer](writer: var Writer,
                                  fieldTag: type FieldTag,


### PR DESCRIPTION
Somehow, creating the `FieldType` as a type messes with the macros used in `NimYAML`. Inline `GetFieldType` to avoid the problem.

https://github.com/status-im/nimbus-eth2/pull/5043#issuecomment-1584219098

```
./nimbus-eth2/tests/consensus_spec/test_fixture_light_client_sync.nim(126, 8) template/generic instantiation of `test` from here
./nimbus-eth2/tests/consensus_spec/test_fixture_light_client_sync.nim(146, 20) template/generic instantiation of `load` from here
./nimbus-eth2/vendor/NimYAML/yaml/serialization.nim(1368, 14) template/generic instantiation of `construct` from here
./nimbus-eth2/vendor/NimYAML/yaml/serialization.nim(1343, 19) template/generic instantiation of `constructChild` from here
./nimbus-eth2/vendor/NimYAML/yaml/serialization.nim(1168, 20) template/generic instantiation of `constructObject` from here
./nimbus-eth2/vendor/NimYAML/yaml/serialization.nim(927, 25) template/generic instantiation of `constructObjectDefault` from here
./nimbus-eth2/vendor/NimYAML/yaml/serialization.nim(921, 31) template/generic instantiation of `ensureAllFieldsPresent` from here
./nimbus-eth2/vendor/NimYAML/yaml/serialization.nim(681, 29) Error: type mismatch: got <NimNode>
but expected one of:
proc none(T: typedesc): Option[T]
  first type mismatch at position: 1
  required type for T: typedesc
  but expression 'nil' is of type: NimNode
proc none[T](): Option[T]
  first type mismatch at position: 1
  extra argument given
template none(O: type Opt; T: type): Opt[T]
  first type mismatch at position: 1
  required type for O: typedesc[Opt]
  but expression 'nil' is of type: NimNode

expression: none(nil)
make: *** [consensus_spec_tests_minimal] Error 1
```