### PR TITLE
add `{.raises.}` annotation to `writeValue`

### DIFF
--- a/serialization.nim
+++ b/serialization.nim
@@ -104,7 +104,8 @@ template saveFile*(Format: type, filename: string, value: auto, params: varargs[
 template borrowSerialization*(Alias: type) {.dirty.} =
   bind distinctBase
 
-  proc writeValue*[Writer](writer: var Writer, value: Alias) =
+  proc writeValue*[Writer](
+      writer: var Writer, value: Alias) {.raises: [IOError].} =
     mixin writeValue
     writeValue(writer, distinctBase value)
 
@@ -115,7 +116,8 @@ template borrowSerialization*(Alias: type) {.dirty.} =
 template borrowSerialization*(Alias: distinct type,
                               OriginalType: distinct type) {.dirty.} =
 
-  proc writeValue*[Writer](writer: var Writer, value: Alias) =
+  proc writeValue*[Writer](
+      writer: var Writer, value: Alias) {.raises: [IOError].} =
     mixin writeValue
     writeValue(writer, OriginalType value)
 
@@ -161,4 +163,3 @@ template writeValue*(stream: OutputStream,
   type WriterType = Writer(Format)
   var writer = unpackArgs(init, [WriterType, stream, params])
   writeValue writer, value
-

--- a/serialization/object_serialization.nim
+++ b/serialization/object_serialization.nim
@@ -408,7 +408,7 @@ proc genCustomSerializationForType(Format, typ: NimNode,
     result.add quote do:
       type WriterType = Writer(`Format`)
       proc writeValue*(`writerSym`: var WriterType, `valueSym`: `typ`)
-                      {.raises: [IOError, Defect], gcsafe.} =
+                      {.raises: [IOError], gcsafe.} =
         `writeBody`
 
 macro useCustomSerialization*(Format: typed, field: untyped, body: untyped): untyped =

--- a/serialization/testing/generic_suite.nim
+++ b/serialization/testing/generic_suite.nim
@@ -113,16 +113,16 @@ Simple.setSerializedFields distance, x, y
 
 proc default(T: typedesc): T = discard
 
-func caseObjectEquals(a, b: CaseObject): bool
+func caseObjectEquals(a, b: CaseObject): bool {.raises: [].}
 
-func `==`*(a, b: CaseObjectRef): bool =
+func `==`*(a, b: CaseObjectRef): bool {.raises: [].} =
   let nils = ord(a.isNil) + ord(b.isNil)
   if nils == 0:
     caseObjectEquals(a[], b[])
   else:
     nils == 2
 
-func caseObjectEquals(a, b: CaseObject): bool =
+func caseObjectEquals(a, b: CaseObject): bool {.raises: [].} =
   # TODO This is needed to work-around a Nim overload selection issue
   if a.kind != b.kind: return false
 
@@ -161,7 +161,7 @@ template roundtripChecks*(Format: type, value: auto, expectedResult: auto) =
   try:
     const typeName = typetraits.name(type(origValue))
     {.warning: "WWW: " & typeName.}
-    
+
     let decoded = Format.decode(serialized, type(origValue))
     checkpoint "(decoded value): " & repr(decoded)
     let success = maybeDefer(decoded) == maybeDefer(origValue)
@@ -369,4 +369,3 @@ proc executeReaderWriterTests*(Format: type) =
         findFieldReader(bazFields[], "some_other_name", pos) == nil
 
   executeRoundtripTests(Format)
-


### PR DESCRIPTION
Tag `writeValue` overrides with `{.raises: [IOError].}`.