### PR TITLE
v0.3.0

### DIFF
--- a/serialization.nimble
+++ b/serialization.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "serialization"
-version       = "0.2.7"
+version       = "0.3.0"
 author        = "Status Research & Development GmbH"
 description   = "A modern and extensible serialization framework for Nim"
 license       = "Apache License 2.0"


### PR DESCRIPTION
Serialization formats now are derived from the `SerializationFormat` which gets used as a namespace marker for `encode`/`decode` etc.

Existing formats should continue to work as long as they use the provided templates to create formats.