### PR TITLE
Reinstate Nim workaround for decode

### DIFF
--- a/serialization.nim
+++ b/serialization.nim
@@ -35,12 +35,11 @@ proc readValue*(
   reader.readValue(result)
   {.warning[ProveInit]: true.}
 
-template decode*(
+template decodeImpl(
     Format: type SerializationFormat,
-    input: string|openArray[char]|seq[byte]|openArray[byte],
+    input: auto,
     RecordType: type,
-    params: varargs[untyped],
-): auto =
+    params: varargs[untyped]): auto =
   mixin init, Reader
   block: # https://github.com/nim-lang/Nim/issues/22874
     {.noSideEffect.}:
@@ -55,6 +54,22 @@ template decode*(
         reader.readValue(RecordType)
       except IOError:
         raise (ref Defect)() # memory inputs cannot raise an IOError
+
+template decode*(
+    Format: type SerializationFormat,
+    input: string,
+    RecordType: type,
+    params: varargs[untyped]): auto =
+  decodeImpl(Format, input, RecordType, params)
+
+template decode*(
+    Format: type SerializationFormat,
+    input: openArray[byte],
+    RecordType: type,
+    params: varargs[untyped]): auto =
+  # TODO, this is dusplicated only due to a Nim bug:
+  # If `input` was `string|openArray[byte]`, it won't match `seq[byte]`
+  decodeImpl(Format, input, RecordType, params)
 
 template loadFile*(
     Format: type SerializationFormat,

--- a/serialization.nim
+++ b/serialization.nim
@@ -64,10 +64,17 @@ template decode*(
 
 template decode*(
     Format: type SerializationFormat,
+    input: openArray[char],
+    RecordType: type,
+    params: varargs[untyped]): auto =
+  decodeImpl(Format, input, RecordType, params)
+
+template decode*(
+    Format: type SerializationFormat,
     input: openArray[byte],
     RecordType: type,
     params: varargs[untyped]): auto =
-  # TODO, this is dusplicated only due to a Nim bug:
+  # TODO, this is duplicated only due to a Nim bug:
   # If `input` was `string|openArray[byte]`, it won't match `seq[byte]`
   decodeImpl(Format, input, RecordType, params)
 


### PR DESCRIPTION
#84 removed a workaround for a Nim bug that required duplication of the `decode` template. This removal was not mentioned in the PR, so may be unintentional. However, the underlying problem is still there, and is surfaced when trying to compile `nim-ssz-serialization`'s tests.

```
/nim-ssz-serialization/tests/test_ssz_union.nim(137, 18) Error: type mismatch
Expression: decode(SSZ, encoded, TestCaseObject)
  [1] SSZ: typedesc[SSZ]
  [2] encoded: array[0..0, byte]
  [3] TestCaseObject: typedesc[TestCaseObject]

Expected one of (first mismatch at [position]):
[2] template decode(Format: type SerializationFormat;
                input: string | openArray[char] | seq[byte] | openArray[byte];
                RecordType: type; params: varargs[untyped]): auto
```

Re-applying the workaround fixes this problem.