### PR TITLE
distinct names for template and proc in decode

### DIFF
--- a/serialization.nim
+++ b/serialization.nim
@@ -48,11 +48,11 @@ template decodeImpl[InputType](
   # past any usage in the unsafe memory input - crucially, proc parameters are
   # also compatible with `openArray`
   type ReturnType = instantiate(RecordType)
-  proc decodeProc(
+  # TODO `proc decodeProc .. {.gensym.} causes duplicate symbols
+  let decodeProc = proc(
       input: InputType
   ): ReturnType {.
       nimcall,
-      gensym,
       raises: [SerializationError],
       forward: (params),
       noxcannotraisey,

--- a/serialization/macros.nim
+++ b/serialization/macros.nim
@@ -56,9 +56,9 @@ macro forward*(args, prc: untyped): untyped =
       # need $ here to ensure it's a freshly looked up identifier, in case there
       # are symbol conflicts - would be nice if `unpackForwarded` could reuse
       # this exact ident instance ..
-      prc.params.add nnkIdentDefs.newTree(ident $arg[0], autoKeyword, newEmptyNode())
+      prc.params.add nnkIdentDefs.newTree(ident $arg[0], nnkCall.newTree(ident "typeof", arg[1]), newEmptyNode())
     else:
-      prc.params.add nnkIdentDefs.newTree(ident "fwd" & $i, autoKeyword, newEmptyNode())
+      prc.params.add nnkIdentDefs.newTree(ident "fwd" & $i, nnkCall.newTree(ident "typeof", arg[0]), newEmptyNode())
     i += 1
   prc
 


### PR DESCRIPTION
there can only be so many `decodeImpl`