### PR TITLE
more targeted backwards compatibility hack for typedescUnpeel

### DIFF
--- a/serialization.nimble
+++ b/serialization.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "serialization"
-version       = "0.4.6"
+version       = "0.4.8"
 author        = "Status Research & Development GmbH"
 description   = "A modern and extensible serialization framework for Nim"
 license       = "Apache License 2.0"


### PR DESCRIPTION
The `instantiate` macro somehow reorders type instantiation which breaks
consumers like json-rpc that use the "original" type for introspection
to give human-readable type names - if `instantiate` is used, these
instead look like `ReturnType'gensym` as instantiations are reordered.

Writing a test for this remains elusive but the error can be seen in
https://github.com/status-im/nim-json-rpc/actions/runs/16615209357/job/47477026290