### PR TITLE
refc: extend input lifetime past unsafe memory input - try nb. 2

### DIFF
--- a/serialization.nim
+++ b/serialization.nim
@@ -77,20 +77,18 @@ template decodeImpl[InputType](
         var reader = unpackForwarded(init, [ReaderType, stream, params])
         reader.readValue(result)
     except IOError:
-      when not defined(gcDestructors):
-        # TODO https://github.com/nim-lang/Nim/issues/25080
-        # Touch the input to avoid GC issues in case `decodeImpl` is inlined
-        # Conveniently, the exception handler must outlive the `reader`
-        # This defect will never actually be raised so `msg` doesn't matter
-        # but we want to keep the codegen relatively short to avoid bloat
-        raiseAssert(
-          if input.len > 0:
-            "memory input doesn't raise IOError"
-          else:
-            "memory input doesn't raise IOError 0"
-        )
-      else:
-        raiseAssert "memory input doesn't raise IOError"
+      raiseAssert "memory input doesn't raise IOError"
+
+    when not defined(gcDestructors):
+      # TODO https://github.com/nim-lang/Nim/issues/25080
+      # Touch the input to avoid GC issues in case `decodeImpl` is inlined
+      # Conveniently, the exception handler must outlive the `reader`
+      # This defect will never actually be raised so `msg` doesn't matter
+      # but we want to keep the codegen relatively short to avoid bloat
+      if input.len < 0:
+        # Adding the most meaningless check possible, to avoid collection
+        # Something's terribly wrong if we're reaching this point
+        raiseAssert "negative memory input length"
 
   unpackForwarded(decodeProc, [inputParam, params])
 


### PR DESCRIPTION
https://github.com/status-im/nim-serialization/pull/91 This PR has extended the input lifetime in the `except` block. This seemed fine on mac and linux. However on Android the `decode` started failing again. It behaves like the `except` block is simply optimized out and the `input` is prematurely collected .

Now we'll have to find the lightest possible way to extend the `input` lifetime without risking some aggressive optimization that will result in optimizing the code out.