### PR TITLE
chore: compile-time error bypass

### DIFF
--- a/serialization/object_serialization.nim
+++ b/serialization/object_serialization.nim
@@ -221,12 +221,12 @@ proc makeFieldReadersTable(RecordType, ReaderType: distinct type,
   var idx {.used.} = 0 # used in case there are no fields..
 
   enumAllSerializedFields(RecordType):
-    if fieldCaseDiscriminator != "":
+    when fieldCaseDiscriminator != "":
       # We don't automatically generate readers for case values since doing so
       # generically would require parsing into temporaries and creating the
       # instance afterwards which is complex
-      error("Case object `" & $RecordType &
-            "` must have custom `readValue` for `" & $ReaderType & "`")
+      static:
+        error "Case object `" & $RecordType & "` must have custom `readValue` for `" & $ReaderType & "`"
 
     proc readField(obj: var RecordType, reader: var ReaderType)
                     {.gcsafe, nimcall, raises: [IOError, SerializationError].} =


### PR DESCRIPTION
Description: This PR fixes a compilation error that occurs when using the serialization library with Nim 2.0. The issue arises because error is now a compile-time only macro in Nim 2.0, but was being used in a runtime context.
