### PR TITLE
Bump minimum Nim to 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      nim-versions: ${{ steps.nim-versions.outputs.nim-versions }}
+    permissions: {}
+    steps:
+      - name: Disable Nim version-1-6
+        id: nim-versions
+        run: |
+          workflow="$(curl 'https://raw.githubusercontent.com/status-im/nimbus-common-workflow/main/.github/workflows/common.yml')"
+          versions=$(echo "$workflow" | yq '.on.workflow_call.inputs["nim-versions"].default')
+          if [[ "$(echo "$versions" | jq 'index("version-1-6")')" == "null" ]]; then
+            echo "version-1-6 no longer needs to be filtered, prepare job can be removed from ci.yml"
+            exit 1
+          fi
+          filtered_versions="$(echo "$versions" | jq -c 'map(select(. != "version-1-6"))')"
+          echo "nim-versions=${filtered_versions}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
+    permissions:
+      contents: read
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
+    with:
+      nim-versions: ${{ needs.prepare.outputs.nim-versions }}

--- a/serialization.nimble
+++ b/serialization.nimble
@@ -1,13 +1,13 @@
 mode = ScriptMode.Verbose
 
 packageName   = "serialization"
-version       = "0.4.9"
+version       = "0.5.0"
 author        = "Status Research & Development GmbH"
 description   = "A modern and extensible serialization framework for Nim"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.6.0",
+requires "nim >= 2.0.0",
          "faststreams",
          "unittest2",
          "stew"
@@ -27,8 +27,7 @@ proc build(args, path: string) =
 
 proc run(args, path: string) =
   build args & " --mm:refc -r", path
-  if (NimMajor, NimMinor) > (1, 6):
-    build args & " --mm:orc -r", path
+  build args & " --mm:orc -r", path
 
 task test, "Run all tests":
   for threads in ["--threads:off", "--threads:on"]:

--- a/serialization/macros.nim
+++ b/serialization/macros.nim
@@ -20,26 +20,24 @@ iterator usefulArgs(args: NimNode): NimNode =
 macro noxcannotraisey*(prc: untyped): untyped =
   # Using `{.pragma: noraiseshint, ....}` doesn't work in a template because of module
   # export issues
-  when (NimMajor, NimMinor) >= (2, 0):
-    if prc.pragma.kind == nnkEmpty:
-      prc.pragma = nnkPragma.newTree()
+  if prc.pragma.kind == nnkEmpty:
+    prc.pragma = nnkPragma.newTree()
 
-    prc.pragma.add nnkExprColonExpr.newTree(
-      nnkBracketExpr.newTree(ident "hint", ident"XCannotRaiseY"), ident"off"
-    )
+  prc.pragma.add nnkExprColonExpr.newTree(
+    nnkBracketExpr.newTree(ident "hint", ident"XCannotRaiseY"), ident"off"
+  )
 
   prc
 
 macro noproveinit*(prc: untyped): untyped =
   # Using `{.pragma: noraiseshint, ....}` doesn't work in a template because of module
   # export issues
-  when (NimMajor, NimMinor) >= (2, 0):
-    if prc.pragma.kind == nnkEmpty:
-      prc.pragma = nnkPragma.newTree()
+  if prc.pragma.kind == nnkEmpty:
+    prc.pragma = nnkPragma.newTree()
 
-    prc.pragma.add nnkExprColonExpr.newTree(
-      nnkBracketExpr.newTree(ident "warning", ident"ProveInit"), ident"off"
-    )
+  prc.pragma.add nnkExprColonExpr.newTree(
+    nnkBracketExpr.newTree(ident "warning", ident"ProveInit"), ident"off"
+  )
 
   prc
 


### PR DESCRIPTION
The version v0.4.9 is the last one to support Nim 1.6, remove the conditional compilation and assume minimum Nim 2.0 going forward.