### PR TITLE
Format versioning facilitate backward compatibility upgrade

### DIFF
--- a/serialization/formats.nim
+++ b/serialization/formats.nim
@@ -14,29 +14,55 @@ type
     ## formats are supported
 
 template serializationFormatImpl(Name: untyped,
-                                 mimeTypeName: static string = "") {.dirty.} =
+                                 mimeTypeName: static string = "",
+                                 version: static uint = 0) {.dirty.} =
   # This indirection is required in order to be able to generate the
   # `mimeType` accessor template. Without the indirection, the template
   # mechanism of Nim will try to expand the `mimeType` param in the position
   # of the `mimeType` template name which will result in error.
   type Name* = object of SerializationFormat
   template mimeType*(T: type Name): string = mimeTypeName
+  template versionInt*(T: type Name): uint = version
 
-template serializationFormat*(Name: untyped, mimeType: static string = "") =
-  serializationFormatImpl(Name, mimeType)
+template serializationFormat*(Name: untyped,
+                              mimeType: static string = "",
+                              version: static uint = 0) =
+  serializationFormatImpl(Name, mimeType, version)
+
+# version behavior
+# 0:
+#   - Reader/Writer using DefaultFlavor
+#   - SerializationFormat is the Flavor parent type
+# 1:
+#   - Reader/Writer using Format as default flavor
+#   - Format is the Flavor parent type
+
+template formatDefaultFlavor(Format: type): type =
+  when Format.versionInt() == 0:
+    DefaultFlavor
+  else:
+    Format
+
+template formatFlavorParent(Format: type): type =
+  when Format.versionInt() == 0:
+    SerializationFormat
+  else:
+    Format
 
 template setReader*(Format: type SerializationFormat, FormatReader: distinct type) =
   when arity(FormatReader) > 1:
-    template ReaderType*(T: type Format, F: distinct type = DefaultFlavor): type = FormatReader[F]
-    template Reader*(T: type Format, F: distinct type = DefaultFlavor): type = FormatReader[F]
+    type Flavor = formatDefaultFlavor(Format)
+    template ReaderType*(T: type Format, F: distinct type = Flavor): type = FormatReader[F]
+    template Reader*(T: type Format, F: distinct type = Flavor): type = FormatReader[F]
   else:
     template ReaderType*(T: type Format): type = FormatReader
     template Reader*(T: type Format): type = FormatReader
 
 template setWriter*(Format: type SerializationFormat, FormatWriter, PreferredOutput: distinct type) =
   when arity(FormatWriter) > 1:
-    template WriterType*(T: type Format, F: distinct type = DefaultFlavor): type = FormatWriter[F]
-    template Writer*(T: type Format, F: distinct type = DefaultFlavor): type = FormatWriter[F]
+    type Flavor = formatDefaultFlavor(Format)
+    template WriterType*(T: type Format, F: distinct type = Flavor): type = FormatWriter[F]
+    template Writer*(T: type Format, F: distinct type = Flavor): type = FormatWriter[F]
   else:
     template WriterType*(T: type Format): type = FormatWriter
     template Writer*(T: type Format): type = FormatWriter
@@ -48,7 +74,7 @@ template createFlavor*(
     FlavorName: untyped,
     mimeTypeName: static string = ""
 ) =
-  type FlavorName* = object of SerializationFormat
+  type FlavorName* = object of formatFlavorParent(ModifiedFormat)
   template Reader*(T: type FlavorName): type = Reader(ModifiedFormat, FlavorName)
   template Writer*(T: type FlavorName): type = Writer(ModifiedFormat, FlavorName)
   template PreferredOutputType*(T: type FlavorName): type = PreferredOutputType(ModifiedFormat)

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -3,4 +3,5 @@ import
   test_object_serialization,
   test_reader,
   test_serializer,
-  test_generic_suite
+  test_generic_suite,
+  test_flavor

--- a/tests/test_flavor.nim
+++ b/tests/test_flavor.nim
@@ -1,0 +1,37 @@
+{.used.}
+
+import
+  unittest2,
+  ../serialization
+
+serializationFormat ParentFormat, version = 1
+
+type
+  SomeReader[Flavor = ParentFormat] = object
+  SomeWriter[Flavor = ParentFormat] = object
+
+ParentFormat.setReader SomeReader
+ParentFormat.setWriter SomeWriter, PreferredOutput = string
+
+createFlavor ParentFormat, ChildFlavor
+
+template sound(_: type ParentFormat): string = "meow"
+func speed(_: type ParentFormat): int = 1001
+
+suite "Flavor":
+  test "flavor inherited from serializationFormat":
+    check ChildFlavor is ParentFormat
+
+  test "flavor can use parent template":
+    check ChildFlavor.sound() == "meow"
+
+  test "flavor can use parent function":
+    check ChildFlavor.speed() == 1001
+
+  test "flavor reader/writer type":
+    check Reader(ChildFlavor) is SomeReader[ChildFlavor]
+    check Writer(ChildFlavor) is SomeWriter[ChildFlavor]
+
+  test "default flavor reader/writer type is parent type":
+    check Reader(ParentFormat) is SomeReader[ParentFormat]
+    check Writer(ParentFormat) is SomeWriter[ParentFormat]

--- a/tests/test_serializer.nim
+++ b/tests/test_serializer.nim
@@ -1,3 +1,4 @@
+{.used.}
 {.push raises: [], gcsafe.}
 
 import


### PR DESCRIPTION
Version behavior
- 0 (original):
  - Reader/Writer using DefaultFlavor
  - SerializationFormat is the Flavor parent type
- 1:
  - Reader/Writer using Format as default flavor
  - Format is the Flavor parent type

Version 1 behavior is useful e.g. Format overloaded the `decode` function.
Then Flavor can reuse the overloaded function without resort to template
workaround.

Replacing the DefaultFlavor with the Format itself also prevent sharing
ambiguity when DefaultFlavor happen to have the same functions/templates
across different Format implementation.