### PR TITLE
specify the version of unittest2 dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,28 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      nim-versions: ${{ steps.nim-versions.outputs.nim-versions }}
-    permissions: {}
-    steps:
-      - name: Disable Nim version-1-6
-        id: nim-versions
-        run: |
-          workflow="$(curl 'https://raw.githubusercontent.com/status-im/nimbus-common-workflow/main/.github/workflows/common.yml')"
-          versions=$(echo "$workflow" | yq '.on.workflow_call.inputs["nim-versions"].default')
-          if [[ "$(echo "$versions" | jq 'index("version-1-6")')" == "null" ]]; then
-            echo "version-1-6 no longer needs to be filtered, prepare job can be removed from ci.yml"
-            exit 1
-          fi
-          filtered_versions="$(echo "$versions" | jq -c 'map(select(. != "version-1-6"))')"
-          echo "nim-versions=${filtered_versions}" >> "$GITHUB_OUTPUT"
-
   build:
-    needs: prepare
     permissions:
       contents: read
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
-    with:
-      nim-versions: ${{ needs.prepare.outputs.nim-versions }}

--- a/serialization.nimble
+++ b/serialization.nimble
@@ -1,16 +1,16 @@
 mode = ScriptMode.Verbose
 
 packageName   = "serialization"
-version       = "0.5.3"
+version       = "0.5.4"
 author        = "Status Research & Development GmbH"
 description   = "A modern and extensible serialization framework for Nim"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 2.0.0",
-         "faststreams",
-         "unittest2",
-         "stew"
+requires "nim >= 2.0.10",
+         "faststreams >= 0.5.0",
+         "stew >= 0.5.0",
+         "unittest2 >= 0.2.0"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)


### PR DESCRIPTION
Otherwise, nimble's `--resolver:minver` picks up unittest2 0.0.1, which doesn't work.
Also, take an opportunity to specify the minimal versions for other dependencies.